### PR TITLE
Fix ローカルのテスト実行時に出るwarningと異様なログ出力の修正

### DIFF
--- a/webapp/backend/internal/service/robot.go
+++ b/webapp/backend/internal/service/robot.go
@@ -6,9 +6,6 @@ import (
 	"backend/internal/service/utils"
 	"context"
 	"log"
-	
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 type RobotService struct {
@@ -20,48 +17,27 @@ func NewRobotService(store *repository.Store) *RobotService {
 }
 
 func (s *RobotService) GenerateDeliveryPlan(ctx context.Context, robotID string, capacity int) (*model.DeliveryPlan, error) {
-	tracer := otel.Tracer("service.robot")
-	ctx, span := tracer.Start(ctx, "RobotService.GenerateDeliveryPlan")
-	defer span.End()
-	span.SetAttributes(attribute.String("robot.id", robotID), attribute.Int("robot.capacity", capacity))
-
 	var plan model.DeliveryPlan
 
 	err := utils.WithTimeout(ctx, func(ctx context.Context) error {
 		return s.store.ExecTx(ctx, func(txStore *repository.Store) error {
-			_, ordersSpan := tracer.Start(ctx, "GetShippingOrders")
 			orders, err := txStore.OrderRepo.GetShippingOrders(ctx)
-			ordersSpan.SetAttributes(attribute.Int("orders.count", len(orders)))
-			ordersSpan.End()
 			if err != nil {
 				return err
 			}
-			
-			_, planSpan := tracer.Start(ctx, "SelectOrdersForDelivery")
 			plan, err = selectOrdersForDelivery(ctx, orders, robotID, capacity)
-			planSpan.SetAttributes(
-				attribute.Int("plan.orders_count", len(plan.Orders)),
-				attribute.Int("plan.total_weight", plan.TotalWeight),
-				attribute.Int("plan.total_value", plan.TotalValue),
-			)
-			planSpan.End()
 			if err != nil {
 				return err
 			}
-			
 			if len(plan.Orders) > 0 {
 				orderIDs := make([]int64, len(plan.Orders))
 				for i, order := range plan.Orders {
 					orderIDs[i] = order.OrderID
 				}
 
-				_, updateSpan := tracer.Start(ctx, "UpdateOrderStatuses")
 				if err := txStore.OrderRepo.UpdateStatuses(ctx, orderIDs, "delivering"); err != nil {
-					updateSpan.End()
 					return err
 				}
-				updateSpan.SetAttributes(attribute.Int("updated.orders_count", len(orderIDs)))
-				updateSpan.End()
 				log.Printf("Updated status to 'delivering' for %d orders", len(orderIDs))
 			}
 			return nil
@@ -80,74 +56,56 @@ func (s *RobotService) UpdateOrderStatus(ctx context.Context, orderID int64, new
 }
 
 func selectOrdersForDelivery(ctx context.Context, orders []model.Order, robotID string, robotCapacity int) (model.DeliveryPlan, error) {
-	// 動的プログラミングによるナップサック解法（最適解を保証）
-	
-	// 重量0以下の注文を除外
-	var validOrders []model.Order
-	for _, order := range orders {
-		if order.Weight > 0 && order.Weight <= robotCapacity {
-			validOrders = append(validOrders, order)
+	n := len(orders)
+	bestValue := 0
+	var bestSet []model.Order
+	steps := 0
+	checkEvery := 16384
+
+	var dfs func(i, curWeight, curValue int, curSet []model.Order) bool
+	dfs = func(i, curWeight, curValue int, curSet []model.Order) bool {
+		if curWeight > robotCapacity {
+			return false
 		}
-	}
-	
-	n := len(validOrders)
-	if n == 0 {
-		return model.DeliveryPlan{
-			RobotID:     robotID,
-			TotalWeight: 0,
-			TotalValue:  0,
-			Orders:      []model.Order{},
-		}, nil
-	}
-	
-	// DP配列: dp[i][w] = i番目までの注文を使って重量wまでの最大価値
-	dp := make([][]int, n+1)
-	for i := range dp {
-		dp[i] = make([]int, robotCapacity+1)
-	}
-	
-	// DPテーブルを構築
-	for i := 1; i <= n; i++ {
-		// コンテキストのキャンセルをチェック
-		select {
-		case <-ctx.Done():
-			return model.DeliveryPlan{}, ctx.Err()
-		default:
-		}
-		
-		order := validOrders[i-1]
-		for w := 0; w <= robotCapacity; w++ {
-			// この注文を選ばない場合
-			dp[i][w] = dp[i-1][w]
-			
-			// この注文を選ぶ場合（重量が許す場合）
-			if w >= order.Weight {
-				dp[i][w] = max(dp[i][w], dp[i-1][w-order.Weight]+order.Value)
+		steps++
+		if checkEvery > 0 && steps%checkEvery == 0 {
+			select {
+			case <-ctx.Done():
+				return true
+			default:
 			}
 		}
-	}
-	
-	// 最適解の復元
-	var selectedOrders []model.Order
-	totalWeight := 0
-	totalValue := dp[n][robotCapacity]
-	
-	w := robotCapacity
-	for i := n; i > 0 && w > 0; i-- {
-		// この注文が選ばれているかチェック
-		if dp[i][w] != dp[i-1][w] {
-			order := validOrders[i-1]
-			selectedOrders = append(selectedOrders, order)
-			totalWeight += order.Weight
-			w -= order.Weight
+		if i == n {
+			if curValue > bestValue {
+				bestValue = curValue
+				bestSet = append([]model.Order{}, curSet...)
+			}
+			return false
 		}
+
+		if dfs(i+1, curWeight, curValue, curSet) {
+			return true
+		}
+
+		order := orders[i]
+		return dfs(i+1, curWeight+order.Weight, curValue+order.Value, append(curSet, order))
+	}
+
+	canceled := dfs(0, 0, 0, nil)
+	if canceled {
+		return model.DeliveryPlan{}, ctx.Err()
+	}
+
+	var totalWeight int
+	for _, o := range bestSet {
+		totalWeight += o.Weight
 	}
 
 	return model.DeliveryPlan{
 		RobotID:     robotID,
 		TotalWeight: totalWeight,
-		TotalValue:  totalValue,
-		Orders:      selectedOrders,
+		TotalValue:  bestValue,
+		Orders:      bestSet,
 	}, nil
 }
 


### PR DESCRIPTION
# まだマージはしないでください

ローカルで``bash run.sh``をすると、migrationの部分でWARNINGがでるのと、e2eテストで異様なログの出力がありました

- e2eテストで異様なログの出力
ログに``robot``という文字がたくさん出ていたため、kawanoさんが``/api/robot/delivery-plan ``を修正したコミットを無かったことにしました(削除ではなく、反転した変更をコミットしました)
https://github.com/t-ozzy/cat-42Tokyo-Tuning-2509/commit/e3984564078fcbce007ab02b7eb513ae0c87fc55
無かったことにしてから、異様なログは出力されませんでした

- migrationの部分でWARNINGでる
aiに聞いたところ、以下の部分が原因らしいです

> 問題点を特定できました。[1_add_indexes.sql] と [3_add_products_indexes.sql] の両方で同じインデックスが定義されています。具体的には以下のインデックスが重複しています：
> 
> idx_products_name
> idx_products_description（ただし、1つ目は部分インデックスで長さ制限があります）
> idx_products_value
> idx_products_weight
> また、[1_add_indexes.sql]の中でも idx_orders_product_id が2回定義されています。
> 
> この問題を解決するために、マイグレーションファイルを修正しましょう。最も安全な方法は、インデックス作成前に「IF NOT EXISTS」を使用するか、または既存のインデックスを確認して存在しなければ作成するロジックを追加することです。
